### PR TITLE
Named stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "license": "CC0-1.0",
   "repository": "izaakschroeder/redux-render",
-  "main": "dist/src/lift.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s inline -d dist/src src/",
     "pretest": "npm run prepublish && ./node_modules/.bin/babel -s inline -d dist/test test/",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,13 @@
+export {
+  liftAction,
+  unliftAction,
+  unliftStore,
+  liftStore,
+  unliftReducer,
+  lift,
+} from './lift.js';
+
+export {
+  name,
+  normalize,
+} from './name.js';

--- a/src/name.js
+++ b/src/name.js
@@ -1,0 +1,28 @@
+
+/**
+ * Create a enhancer to add an name property to the store lifted by an enhancer.
+ * @param {string} name The name to apply to the store.
+ * @returns {Function} An enhancer capable of lifting an enhancer.
+ */
+export function name(name) {
+  return enhancer => next => (reducer, initialState) => {
+    return {
+      ...enhancer(next)(reducer, initialState),
+      name,
+    };
+  };
+}
+
+/**
+ * Create a enhancer to add an name property to the store lifted by an enhancer.
+ * The base store will always be available under the `default` property.
+ * @param {Object} store A redux store.
+ * @returns {Object} An object mapping stores to their name properites.
+ */
+export function normalize(store) {
+  const stores = {};
+  for (let current = store; current; current = current.parent) {
+    stores[current.name || 'default'] = current;
+  }
+  return stores;
+}

--- a/test/spec/lift.spec.js
+++ b/test/spec/lift.spec.js
@@ -11,7 +11,7 @@ import {
   unliftAction,
   liftStore,
   lift,
-} from '../../src/lift';
+} from '../../src';
 
 chai.use(sinonChai);
 

--- a/test/spec/name.spec.js
+++ b/test/spec/name.spec.js
@@ -1,0 +1,111 @@
+require('source-map-support').install();
+
+import { createStore, compose } from 'redux';
+import promiseMiddleware from 'redux-promise';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import {
+  liftAction,
+  unliftAction,
+  liftStore,
+  lift,
+} from '../../src/lift';
+
+import { name, normalize } from '../../src/name';
+
+chai.use(sinonChai);
+
+// Simple reducer.
+function app(state, { type, value }) {
+  return type === 'UPDATE' ? state + value : state;
+}
+
+function liftState(a, b = { message: 'hello' }) {
+  return [a,b]
+}
+
+function unliftState([a,b]) {
+  return a;
+}
+
+function liftReducer(reducer) {
+  return (state, action) => {
+    const [a,b] = state;
+    switch(action.type) {
+    case 'CHILD':
+      return liftState(
+        reducer(unliftState(state),
+        unliftAction(action)
+      ), state[1]);
+    case 'MESSAGE':
+      return liftState(unliftState(state), { message: action.payload });
+    default:
+      return state;
+    }
+  }
+}
+
+function liftDispatch(dispatch) {
+  return (action) => dispatch(liftAction('CHILD', action));
+}
+
+const enhancer = lift({
+  liftState,
+  unliftState,
+  liftReducer,
+  liftDispatch
+})
+
+describe('name', () => {
+
+  describe('named store', () => {
+    it('should have a name property', () => {
+      const liftedCreateStore = name('enhanced')(enhancer)(createStore);
+      const store = liftedCreateStore(app, 1);
+      expect(store.name).to.equal('enhanced');
+    });
+
+    it('should affect parent store', () => {
+      const liftedCreateStore = compose(
+        name('enhanced1')(enhancer),
+        name('enhanced2')(enhancer)
+      )(createStore);
+
+      const store = liftedCreateStore(app, 1);
+      expect(store.parent.name).to.equal('enhanced2');
+    });
+  });
+
+  describe('normalize', () => {
+    it('should create a map of named stores', () => {
+      const liftedCreateStore = compose(
+        name('enhanced1')(enhancer),
+        name('enhanced2')(enhancer)
+      )(createStore);
+
+      const stores = normalize(liftedCreateStore(app, 1));
+      expect(stores).to.have.keys('enhanced1', 'enhanced2', 'default');
+    });
+
+
+    it('should preserve the store hierarchy', () => {
+      const liftedCreateStore = compose(
+        name('enhanced1')(enhancer),
+        name('enhanced2')(enhancer),
+        name('enhanced3')(enhancer)
+      )(createStore);
+
+      const store = liftedCreateStore(app, 1);
+      const stores = normalize(store);
+
+      expect(stores.enhanced1).to.equal(store);
+      expect(stores.enhanced2).to.equal(store.parent);
+      expect(stores.enhanced3).to.equal(store.parent.parent);
+      expect(stores.default).to.equal(store.parent.parent.parent);
+    });
+
+  });
+
+});

--- a/test/spec/name.spec.js
+++ b/test/spec/name.spec.js
@@ -11,9 +11,9 @@ import {
   unliftAction,
   liftStore,
   lift,
-} from '../../src/lift';
-
-import { name, normalize } from '../../src/name';
+  name,
+  normalize
+} from '../../src';
 
 chai.use(sinonChai);
 


### PR DESCRIPTION
Specific store levels created by enhancers are difficult to access. By adding the ability to reference each level by name, composition using lift is much more accessible.

Use `name('levelName')(enhancer)` to add a name property to an enhanced store level. It works by enhancing the enhancer that lifts the store.

Use `normalize(store)` to flatten the store-parent hierarchy into a named map. The base store originally accessible at `store.parent... .parent` is accessible as `default` on the map.

**Example Usage**

``` js
const createNamedStores = compose(
  normalize,
  compose(
    name('ephemeral')(ephemeral),
    name('promise')(promise),
    name('devTools')(devTools)
  )(createStore)
);

const stores = createNamedStores(reducer, initialState);
```

results in:

``` js
{
  ephemeral: {
    ...
    parent: { ... },
    name: 'ephemeral'
  },
  promise: {
    ...
    parent: { ... },
    name: 'promise'
  },
  devTools: {
    ...
    parent: { ... },
    name: 'devTools'
  },
  default: {
    ...
  }
}
```
